### PR TITLE
Feat/refresh test

### DIFF
--- a/controllers/cards.ts
+++ b/controllers/cards.ts
@@ -62,8 +62,10 @@ async function updateCard(ctx: Context) {
 
     const { question, answer, submitDate, stackCount } = await request.body()
       .value;
-    if (!question || !answer || !submitDate || !stackCount)
-      throw Error('question, answer, data, stackCount 중 값이 1개 없습니다.');
+    if (!question || !answer || !submitDate || stackCount === undefined)
+      throw Error(
+        'question, answer, submitDate, stackCount 중 값이 1개 없습니다.'
+      );
 
     const card = new CardRecord(
       question,

--- a/controllers/cards.ts
+++ b/controllers/cards.ts
@@ -13,7 +13,8 @@ async function addCard({ request, response, state }: Context) {
 
     const { question, answer, submitDate, stackCount } = await request.body()
       .value;
-    if (!question || !answer || !submitDate || !stackCount)
+    if (!question || !answer || !submitDate || stackCount === undefined)
+      // stackCount의 0은 falsy 하기 때문에 undefined으로 활용
       throw Error(
         'question, answer, submitDate, stackCount 중 값이 1개 없습니다.'
       );

--- a/controllers/cards.ts
+++ b/controllers/cards.ts
@@ -14,7 +14,9 @@ async function addCard({ request, response, state }: Context) {
     const { question, answer, submitDate, stackCount } = await request.body()
       .value;
     if (!question || !answer || !submitDate || !stackCount)
-      throw Error('question, answer, data, stackCount 중 값이 1개 없습니다.');
+      throw Error(
+        'question, answer, submitDate, stackCount 중 값이 1개 없습니다.'
+      );
 
     const card = new CardRecord(
       question,

--- a/util/token.test.ts
+++ b/util/token.test.ts
@@ -66,14 +66,7 @@ Deno.test('should throw error for invalid token', async () => {
   const privateKey = await generateKey();
   const invalidToken = 'invalid-token';
 
-  await assertRejects(
-    async () => {
-      return await convertTokenToUserId(invalidToken, privateKey);
-    },
-    Error,
-    'The serialization of the jwt is invalid.',
-    'throw different error'
-  );
+  assertEquals(await convertTokenToUserId(invalidToken, privateKey), null);
 });
 
 Deno.test('should throw error for expired token', async () => {
@@ -84,12 +77,5 @@ Deno.test('should throw error for expired token', async () => {
     await generateAccessToken(userId, expiresInSec, privateKey)
   ).jwt;
 
-  await assertRejects(
-    async () => {
-      return await convertTokenToUserId(expiredToken, privateKey);
-    },
-    Error,
-    'The jwt is expired.',
-    'throw different error'
-  );
+  assertEquals(await convertTokenToUserId(expiredToken, privateKey), null);
 });

--- a/util/token.ts
+++ b/util/token.ts
@@ -52,8 +52,12 @@ async function generateAccessToken(
  * sub는 라이브러리에서 문자열을 할당하도록 예약되어 있습니다.
  */
 async function convertTokenToUserId(jwt: string, key = privateKey) {
-  const { sub: userId } = await verify(jwt, key);
-  return userId;
+  try {
+    const { sub: userId } = await verify(jwt, key);
+    return userId;
+  } catch (_error) {
+    return null;
+  }
 }
 
 async function refreshAccessToken(refreshToken: string, key = privateKey) {

--- a/util/token.ts
+++ b/util/token.ts
@@ -34,7 +34,7 @@ async function generateRefreshToken(
 
 async function generateAccessToken(
   userId: string,
-  expiresInSec = 30,
+  expiresInSec = 3600,
   key = privateKey
 ) {
   const jwt = await create(

--- a/util/token.ts
+++ b/util/token.ts
@@ -34,7 +34,7 @@ async function generateRefreshToken(
 
 async function generateAccessToken(
   userId: string,
-  expiresInSec = 3600,
+  expiresInSec = 30,
   key = privateKey
 ) {
   const jwt = await create(


### PR DESCRIPTION
- 프론트엔드와 토큰 갱신 결합 테스트를 위해 만들었습니다.
- `convertTokenToUserId`가 401에러를 반환하도록 try-catch문으로 수정했습니다.
- `stackCount`는 `undefined`인지만 확인합니다. 0으로 입력받을 수 있고 0은 falsy하기 때문입니다.
- 카드를 생성할 때 `data`를 `submitDate`로 정정합니다.